### PR TITLE
#4: Show basic list of facts in list screen

### DIFF
--- a/NorrisFacts.xcodeproj/project.pbxproj
+++ b/NorrisFacts.xcodeproj/project.pbxproj
@@ -65,6 +65,10 @@
 		BDB9BA49249F067300B0E5F2 /* MockFactListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA48249F067300B0E5F2 /* MockFactListCoordinator.swift */; };
 		BDB9BA4B249F1C2100B0E5F2 /* FactListItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA4A249F1C2100B0E5F2 /* FactListItemTableViewCell.swift */; };
 		BDB9BA4E249F1C8400B0E5F2 /* FactListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA4D249F1C8300B0E5F2 /* FactListItemViewModel.swift */; };
+		BDCEE6C3249F926A00CA200B /* ErrorDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6C2249F926A00CA200B /* ErrorDescriptor.swift */; };
+		BDCEE6C5249F96BB00CA200B /* UIViewController+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6C4249F96BB00CA200B /* UIViewController+Common.swift */; };
+		BDCEE6C7249F97C300CA200B /* Observable+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6C6249F97C300CA200B /* Observable+Common.swift */; };
+		BDCEE6C9249F97E300CA200B /* Result+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6C8249F97E300CA200B /* Result+Common.swift */; };
 		BDE90509249DBF4E00B2AF28 /* URL+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE90508249DBF4E00B2AF28 /* URL+Common.swift */; };
 		BDE9050B249DCC3200B2AF28 /* Error+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050A249DCC3200B2AF28 /* Error+Common.swift */; };
 		BDE9050D249E4FE600B2AF28 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050C249E4FE600B2AF28 /* APIError.swift */; };
@@ -176,6 +180,10 @@
 		BDB9BA48249F067300B0E5F2 /* MockFactListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFactListCoordinator.swift; sourceTree = "<group>"; };
 		BDB9BA4A249F1C2100B0E5F2 /* FactListItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactListItemTableViewCell.swift; sourceTree = "<group>"; };
 		BDB9BA4D249F1C8300B0E5F2 /* FactListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactListItemViewModel.swift; sourceTree = "<group>"; };
+		BDCEE6C2249F926A00CA200B /* ErrorDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDescriptor.swift; sourceTree = "<group>"; };
+		BDCEE6C4249F96BB00CA200B /* UIViewController+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Common.swift"; sourceTree = "<group>"; };
+		BDCEE6C6249F97C300CA200B /* Observable+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Common.swift"; sourceTree = "<group>"; };
+		BDCEE6C8249F97E300CA200B /* Result+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Common.swift"; sourceTree = "<group>"; };
 		BDE90508249DBF4E00B2AF28 /* URL+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Common.swift"; sourceTree = "<group>"; };
 		BDE9050A249DCC3200B2AF28 /* Error+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Common.swift"; sourceTree = "<group>"; };
 		BDE9050C249E4FE600B2AF28 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
@@ -242,9 +250,13 @@
 			children = (
 				BDE90514249E550100B2AF28 /* Extensions */,
 				BDB9BA3E249EFC0600B0E5F2 /* Coordinator.swift */,
+				BDCEE6C2249F926A00CA200B /* ErrorDescriptor.swift */,
 				BDB9BA37249EDA2200B0E5F2 /* IdentifiableType.swift */,
-				BDB9BA35249EDA0300B0E5F2 /* UIWindow.swift */,
+				BDCEE6C6249F97C300CA200B /* Observable+Common.swift */,
+				BDCEE6C8249F97E300CA200B /* Result+Common.swift */,
 				BDB9BA39249EDA3C00B0E5F2 /* Storyboard.swift */,
+				BDCEE6C4249F96BB00CA200B /* UIViewController+Common.swift */,
+				BDB9BA35249EDA0300B0E5F2 /* UIWindow.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -641,6 +653,10 @@
 				BDE9050D249E4FE600B2AF28 /* APIError.swift in Sources */,
 				BDB9BA36249EDA0300B0E5F2 /* UIWindow.swift in Sources */,
 				BD14F8A4249B7CFB0029B50C /* AppDelegate.swift in Sources */,
+				BDCEE6C5249F96BB00CA200B /* UIViewController+Common.swift in Sources */,
+				BDCEE6C3249F926A00CA200B /* ErrorDescriptor.swift in Sources */,
+				BDCEE6C9249F97E300CA200B /* Result+Common.swift in Sources */,
+				BDCEE6C7249F97C300CA200B /* Observable+Common.swift in Sources */,
 				BD4A264A249EAEF800CC5624 /* FactSearchViewModel.swift in Sources */,
 				BDE9050B249DCC3200B2AF28 /* Error+Common.swift in Sources */,
 				BDB9BA3A249EDA3C00B0E5F2 /* Storyboard.swift in Sources */,

--- a/NorrisFacts.xcodeproj/project.pbxproj
+++ b/NorrisFacts.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		BDCEE6C5249F96BB00CA200B /* UIViewController+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6C4249F96BB00CA200B /* UIViewController+Common.swift */; };
 		BDCEE6C7249F97C300CA200B /* Observable+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6C6249F97C300CA200B /* Observable+Common.swift */; };
 		BDCEE6C9249F97E300CA200B /* Result+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6C8249F97E300CA200B /* Result+Common.swift */; };
+		BDCEE6CB249FD1AF00CA200B /* MockFactsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCEE6CA249FD1AF00CA200B /* MockFactsProvider.swift */; };
 		BDE90509249DBF4E00B2AF28 /* URL+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE90508249DBF4E00B2AF28 /* URL+Common.swift */; };
 		BDE9050B249DCC3200B2AF28 /* Error+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050A249DCC3200B2AF28 /* Error+Common.swift */; };
 		BDE9050D249E4FE600B2AF28 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050C249E4FE600B2AF28 /* APIError.swift */; };
@@ -184,6 +185,7 @@
 		BDCEE6C4249F96BB00CA200B /* UIViewController+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Common.swift"; sourceTree = "<group>"; };
 		BDCEE6C6249F97C300CA200B /* Observable+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Common.swift"; sourceTree = "<group>"; };
 		BDCEE6C8249F97E300CA200B /* Result+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Common.swift"; sourceTree = "<group>"; };
+		BDCEE6CA249FD1AF00CA200B /* MockFactsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFactsProvider.swift; sourceTree = "<group>"; };
 		BDE90508249DBF4E00B2AF28 /* URL+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Common.swift"; sourceTree = "<group>"; };
 		BDE9050A249DCC3200B2AF28 /* Error+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Common.swift"; sourceTree = "<group>"; };
 		BDE9050C249E4FE600B2AF28 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
@@ -418,6 +420,7 @@
 			children = (
 				BDB9BA48249F067300B0E5F2 /* MockFactListCoordinator.swift */,
 				BDB9BA44249F046300B0E5F2 /* MockFactSearchCoordinator.swift */,
+				BDCEE6CA249FD1AF00CA200B /* MockFactsProvider.swift */,
 			);
 			path = TestDoubles;
 			sourceTree = "<group>";
@@ -684,6 +687,7 @@
 				BD7BBBA9249EA18200F1F2D8 /* StubResponse.swift in Sources */,
 				BDB9BA49249F067300B0E5F2 /* MockFactListCoordinator.swift in Sources */,
 				BDB9BA42249EFEAC00B0E5F2 /* FactSearchViewModelTests.swift in Sources */,
+				BDCEE6CB249FD1AF00CA200B /* MockFactsProvider.swift in Sources */,
 				BD7BBBA0249E5D6F00F1F2D8 /* FactsProviderTests.swift in Sources */,
 				BDB9BA47249F04D000B0E5F2 /* FactListViewModelTests.swift in Sources */,
 			);

--- a/NorrisFacts.xcodeproj/project.pbxproj
+++ b/NorrisFacts.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		BDB9BA45249F046300B0E5F2 /* MockFactSearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA44249F046300B0E5F2 /* MockFactSearchCoordinator.swift */; };
 		BDB9BA47249F04D000B0E5F2 /* FactListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA46249F04D000B0E5F2 /* FactListViewModelTests.swift */; };
 		BDB9BA49249F067300B0E5F2 /* MockFactListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA48249F067300B0E5F2 /* MockFactListCoordinator.swift */; };
+		BDB9BA4B249F1C2100B0E5F2 /* FactListItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA4A249F1C2100B0E5F2 /* FactListItemTableViewCell.swift */; };
+		BDB9BA4E249F1C8400B0E5F2 /* FactListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB9BA4D249F1C8300B0E5F2 /* FactListItemViewModel.swift */; };
 		BDE90509249DBF4E00B2AF28 /* URL+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE90508249DBF4E00B2AF28 /* URL+Common.swift */; };
 		BDE9050B249DCC3200B2AF28 /* Error+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050A249DCC3200B2AF28 /* Error+Common.swift */; };
 		BDE9050D249E4FE600B2AF28 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050C249E4FE600B2AF28 /* APIError.swift */; };
@@ -172,6 +174,8 @@
 		BDB9BA44249F046300B0E5F2 /* MockFactSearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFactSearchCoordinator.swift; sourceTree = "<group>"; };
 		BDB9BA46249F04D000B0E5F2 /* FactListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactListViewModelTests.swift; sourceTree = "<group>"; };
 		BDB9BA48249F067300B0E5F2 /* MockFactListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFactListCoordinator.swift; sourceTree = "<group>"; };
+		BDB9BA4A249F1C2100B0E5F2 /* FactListItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactListItemTableViewCell.swift; sourceTree = "<group>"; };
+		BDB9BA4D249F1C8300B0E5F2 /* FactListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactListItemViewModel.swift; sourceTree = "<group>"; };
 		BDE90508249DBF4E00B2AF28 /* URL+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Common.swift"; sourceTree = "<group>"; };
 		BDE9050A249DCC3200B2AF28 /* Error+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Common.swift"; sourceTree = "<group>"; };
 		BDE9050C249E4FE600B2AF28 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
@@ -330,6 +334,7 @@
 			isa = PBXGroup;
 			children = (
 				BDB9BA2E249ECE6A00B0E5F2 /* FactList */,
+				BDB9BA4C249F1C4600B0E5F2 /* FactListItem */,
 				BD4A2648249EAEE400CC5624 /* Search */,
 			);
 			path = Modules;
@@ -403,6 +408,15 @@
 				BDB9BA44249F046300B0E5F2 /* MockFactSearchCoordinator.swift */,
 			);
 			path = TestDoubles;
+			sourceTree = "<group>";
+		};
+		BDB9BA4C249F1C4600B0E5F2 /* FactListItem */ = {
+			isa = PBXGroup;
+			children = (
+				BDB9BA4A249F1C2100B0E5F2 /* FactListItemTableViewCell.swift */,
+				BDB9BA4D249F1C8300B0E5F2 /* FactListItemViewModel.swift */,
+			);
+			path = FactListItem;
 			sourceTree = "<group>";
 		};
 		BDE90513249E545200B2AF28 /* Facts */ = {
@@ -634,12 +648,14 @@
 				BDB9BA38249EDA2200B0E5F2 /* IdentifiableType.swift in Sources */,
 				BDB9BA32249ECEA200B0E5F2 /* FactListViewModel.swift in Sources */,
 				BD5830C8249EAAD3000926B3 /* FactSearchViewController.swift in Sources */,
+				BDB9BA4E249F1C8400B0E5F2 /* FactListItemViewModel.swift in Sources */,
 				BD05AC92249DA83C000F453B /* FactsProvider.swift in Sources */,
 				BDB9BA3F249EFC0600B0E5F2 /* Coordinator.swift in Sources */,
 				BD14F8A8249B7CFB0029B50C /* ContentView.swift in Sources */,
 				BDB9BA34249ED49F00B0E5F2 /* FactListCoordinator.swift in Sources */,
 				BD05AC9D249DB9A9000F453B /* JSONDecoder+API.swift in Sources */,
 				BD7BBBA7249E98E900F1F2D8 /* HttpStatusCode.swift in Sources */,
+				BDB9BA4B249F1C2100B0E5F2 /* FactListItemTableViewCell.swift in Sources */,
 				BDE90512249E521800B2AF28 /* PrimitiveSequence+API.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NorrisFacts/API/Facts/FactsProvider.swift
+++ b/NorrisFacts/API/Facts/FactsProvider.swift
@@ -16,7 +16,7 @@ protocol FactsProviderProtocol {
     func fetchCategories() -> Single<[String]>
 }
 
-struct FactsProvider {
+struct FactsProvider: FactsProviderProtocol {
     private let provider = MoyaProvider<FactsAPI>()
 
     func search(query: String) -> Single<[Fact]> {

--- a/NorrisFacts/Common/ErrorDescriptor.swift
+++ b/NorrisFacts/Common/ErrorDescriptor.swift
@@ -1,0 +1,30 @@
+//
+//  ErrorDescriptor.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/21/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+
+struct ErrorDescriptor {
+    let id: Int
+    let message: String
+
+    var title: String {
+        "Error #\(id)"
+    }
+
+    static var general: ErrorDescriptor {
+        .init(id: 1, message: "An unexpected error just occurred, please try again later")
+    }
+
+    static var server: ErrorDescriptor {
+        .init(id: 2, message: "Failed to connect to server, please try again later")
+    }
+
+    static var network: ErrorDescriptor {
+        .init(id: 3, message: "Please check your internet connection")
+    }
+}

--- a/NorrisFacts/Common/IdentifiableType.swift
+++ b/NorrisFacts/Common/IdentifiableType.swift
@@ -19,3 +19,5 @@ extension IdentifiableType {
 }
 
 extension UIViewController: IdentifiableType {}
+
+extension UITableViewCell: IdentifiableType {}

--- a/NorrisFacts/Common/Observable+Common.swift
+++ b/NorrisFacts/Common/Observable+Common.swift
@@ -1,0 +1,19 @@
+//
+//  Observable+Common.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/21/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+extension Observable {
+    func mapToResult() -> Observable<Result<Element, Error>> {
+        map { .success($0) }
+            .catchError { error -> Observable<Result<Element, Error>> in
+                .just(.failure(error))
+            }
+    }
+}

--- a/NorrisFacts/Common/Result+Common.swift
+++ b/NorrisFacts/Common/Result+Common.swift
@@ -1,0 +1,18 @@
+//
+//  Result+Common.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/21/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+
+extension Result {
+    func getError() -> Failure? {
+        guard case let .failure(error) = self else {
+            return nil
+        }
+        return error
+    }
+}

--- a/NorrisFacts/Common/UIViewController+Common.swift
+++ b/NorrisFacts/Common/UIViewController+Common.swift
@@ -1,0 +1,21 @@
+//
+//  UIViewController+Common.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/21/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    func alert(error: ErrorDescriptor) {
+        let alert = UIAlertController(
+            title: error.title,
+            message: error.message,
+            preferredStyle: .alert
+        )
+        alert.addAction(.init(title: "Ok", style: .default, handler: nil))
+        present(alert, animated: true, completion: nil)
+    }
+}

--- a/NorrisFacts/Entity/Fact.swift
+++ b/NorrisFacts/Entity/Fact.swift
@@ -15,3 +15,5 @@ struct Fact: Decodable {
     let iconUrl: String
     let categories: [String]
 }
+
+extension Fact: Equatable {}

--- a/NorrisFacts/Main.storyboard
+++ b/NorrisFacts/Main.storyboard
@@ -14,7 +14,46 @@
                     <view key="view" contentMode="scaleToFill" id="tkC-MS-qpD">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="8Ke-fH-m8e">
+                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FactListItemTableViewCell" rowHeight="77" id="81R-Tk-Hsr" customClass="FactListItemTableViewCell" customModule="NorrisFacts" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="414" height="77"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="81R-Tk-Hsr" id="1v4-Oa-Vha">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="77"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Freddy has nightmares about Chuck Norris" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jGk-28-LSg">
+                                                    <rect key="frame" x="16" y="16" width="382" height="45"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="jGk-28-LSg" secondAttribute="trailing" constant="16" id="Bcg-t3-K30"/>
+                                                <constraint firstAttribute="bottom" secondItem="jGk-28-LSg" secondAttribute="bottom" constant="16" id="evS-wK-l3c"/>
+                                                <constraint firstItem="jGk-28-LSg" firstAttribute="top" secondItem="1v4-Oa-Vha" secondAttribute="top" constant="16" id="oSQ-Nz-Om9"/>
+                                                <constraint firstItem="jGk-28-LSg" firstAttribute="leading" secondItem="1v4-Oa-Vha" secondAttribute="leading" constant="16" id="wVh-uG-v6m"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="valueLabel" destination="jGk-28-LSg" id="h3I-pC-e3F"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="Ohb-6B-voi" firstAttribute="trailing" secondItem="8Ke-fH-m8e" secondAttribute="trailing" id="Em2-TS-w6q"/>
+                            <constraint firstItem="8Ke-fH-m8e" firstAttribute="top" secondItem="Ohb-6B-voi" secondAttribute="top" id="PgR-yM-l2b"/>
+                            <constraint firstItem="8Ke-fH-m8e" firstAttribute="leading" secondItem="Ohb-6B-voi" secondAttribute="leading" id="T9t-8D-ycJ"/>
+                            <constraint firstAttribute="bottom" secondItem="8Ke-fH-m8e" secondAttribute="bottom" id="isX-Tl-oBz"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Ohb-6B-voi"/>
                     </view>
                     <navigationItem key="navigationItem" title="Facts" id="JNW-gw-D87">
@@ -22,11 +61,12 @@
                     </navigationItem>
                     <connections>
                         <outlet property="searchBarButton" destination="fCf-4W-2x7" id="Pei-n3-CUT"/>
+                        <outlet property="tableView" destination="8Ke-fH-m8e" id="fNL-57-JXb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CwN-xJ-VA3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-758" y="-522"/>
+            <point key="canvasLocation" x="-759.4202898550725" y="-522.32142857142856"/>
         </scene>
         <!--Search Facts-->
         <scene sceneID="tOP-Hu-y8c">

--- a/NorrisFacts/Main.storyboard
+++ b/NorrisFacts/Main.storyboard
@@ -15,6 +15,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No results" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nlD-lo-GZ7">
+                                <rect key="frame" x="168" y="437.5" width="78" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="8Ke-fH-m8e">
                                 <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -53,6 +59,8 @@
                             <constraint firstItem="8Ke-fH-m8e" firstAttribute="top" secondItem="Ohb-6B-voi" secondAttribute="top" id="PgR-yM-l2b"/>
                             <constraint firstItem="8Ke-fH-m8e" firstAttribute="leading" secondItem="Ohb-6B-voi" secondAttribute="leading" id="T9t-8D-ycJ"/>
                             <constraint firstAttribute="bottom" secondItem="8Ke-fH-m8e" secondAttribute="bottom" id="isX-Tl-oBz"/>
+                            <constraint firstItem="nlD-lo-GZ7" firstAttribute="centerY" secondItem="tkC-MS-qpD" secondAttribute="centerY" id="t9T-ly-vty"/>
+                            <constraint firstItem="nlD-lo-GZ7" firstAttribute="centerX" secondItem="tkC-MS-qpD" secondAttribute="centerX" id="xny-Fn-8Gs"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Ohb-6B-voi"/>
                     </view>
@@ -60,6 +68,7 @@
                         <barButtonItem key="rightBarButtonItem" systemItem="search" id="fCf-4W-2x7"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="messageLabel" destination="nlD-lo-GZ7" id="hge-Tj-9zB"/>
                         <outlet property="searchBarButton" destination="fCf-4W-2x7" id="Pei-n3-CUT"/>
                         <outlet property="tableView" destination="8Ke-fH-m8e" id="fNL-57-JXb"/>
                     </connections>

--- a/NorrisFacts/Main.storyboard
+++ b/NorrisFacts/Main.storyboard
@@ -41,14 +41,22 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <textInputTraits key="textInputTraits" returnKeyType="search"/>
                             </searchBar>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="2Tu-dj-96v">
+                                <rect key="frame" x="197" y="438" width="20" height="20"/>
+                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="2Tu-dj-96v" firstAttribute="centerX" secondItem="wN5-nW-pAS" secondAttribute="centerX" id="VZF-kg-A6W"/>
+                            <constraint firstItem="2Tu-dj-96v" firstAttribute="centerY" secondItem="wN5-nW-pAS" secondAttribute="centerY" id="olO-Ag-82m"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="yiS-ha-PVB"/>
                     </view>
                     <navigationItem key="navigationItem" title="Search Facts" id="APw-IJ-bsC">
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="ERq-Pm-RMf"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="activityIndicator" destination="2Tu-dj-96v" id="Rv9-aZ-tiL"/>
                         <outlet property="cancelBarButton" destination="ERq-Pm-RMf" id="jLL-iq-2K9"/>
                         <outlet property="searchBar" destination="ooK-vo-asS" id="s8a-5P-PAt"/>
                     </connections>

--- a/NorrisFacts/Modules/FactList/FactListCoordinator.swift
+++ b/NorrisFacts/Modules/FactList/FactListCoordinator.swift
@@ -44,12 +44,9 @@ final class FactListCoordinator: FactListCoordinatorProtocol {
     func startSearch() {
         guard let navigationController = navigationController else { return }
 
-        searchCoordinator = FactSearchCoordinator(parent: navigationController, storyboard: storyboard) { [weak self] results in
+        searchCoordinator = FactSearchCoordinator(parent: navigationController, storyboard: storyboard) { [weak self] result in
             self?.searchCoordinator = nil
-
-            if let searchResults = results {
-                self?.viewModel?.update(searchResults: searchResults)
-            }
+            self?.viewModel?.update(searchResult: result)
         }
         searchCoordinator?.start()
     }

--- a/NorrisFacts/Modules/FactList/FactListCoordinator.swift
+++ b/NorrisFacts/Modules/FactList/FactListCoordinator.swift
@@ -18,6 +18,7 @@ final class FactListCoordinator: FactListCoordinatorProtocol {
     private let storyboard: StoryboardProtocol
     private var navigationController: UINavigationController?
     private var searchCoordinator: FactSearchCoordinator?
+    private var viewModel: FactListViewModel?
 
     init(window: UIWindowProtocol, storyboard: StoryboardProtocol) {
         self.window = window
@@ -34,6 +35,7 @@ final class FactListCoordinator: FactListCoordinatorProtocol {
 
         let viewModel = FactListViewModel(coordinator: self)
         viewController.viewModel = viewModel
+        self.viewModel = viewModel
 
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
@@ -42,8 +44,12 @@ final class FactListCoordinator: FactListCoordinatorProtocol {
     func startSearch() {
         guard let navigationController = navigationController else { return }
 
-        searchCoordinator = FactSearchCoordinator(parent: navigationController, storyboard: storyboard) { [weak self] _ in
+        searchCoordinator = FactSearchCoordinator(parent: navigationController, storyboard: storyboard) { [weak self] results in
             self?.searchCoordinator = nil
+
+            if let searchResults = results {
+                self?.viewModel?.update(searchResults: searchResults)
+            }
         }
         searchCoordinator?.start()
     }

--- a/NorrisFacts/Modules/FactList/FactListViewController.swift
+++ b/NorrisFacts/Modules/FactList/FactListViewController.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 final class FactListViewController: UIViewController {
     @IBOutlet private weak var searchBarButton: UIBarButtonItem!
+    @IBOutlet private weak var tableView: UITableView!
 
     private let bag = DisposeBag()
 
@@ -21,12 +22,25 @@ final class FactListViewController: UIViewController {
         super.viewDidLoad()
 
         bindViewModelInput()
+        bindViewModelOutput()
     }
 
     private func bindViewModelInput() {
         let input = FactListViewModelInput(searchBarButtonTap: searchBarButton.rx.tap.asObservable())
         viewModel?
             .bind(input: input)
+            .disposed(by: bag)
+    }
+
+    private func bindViewModelOutput() {
+        guard let input = viewModel?.output else { return }
+
+        let cellType = FactListItemTableViewCell.self
+        input
+            .items
+            .drive(tableView.rx.items(cellIdentifier: cellType.id, cellType: cellType)) { _, itemViewModel, cell in
+                cell.viewModel = itemViewModel
+            }
             .disposed(by: bag)
     }
 }

--- a/NorrisFacts/Modules/FactList/FactListViewController.swift
+++ b/NorrisFacts/Modules/FactList/FactListViewController.swift
@@ -13,6 +13,7 @@ import RxSwift
 final class FactListViewController: UIViewController {
     @IBOutlet private weak var searchBarButton: UIBarButtonItem!
     @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var messageLabel: UILabel!
 
     private let bag = DisposeBag()
 
@@ -21,8 +22,13 @@ final class FactListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setupView()
         bindViewModelInput()
         bindViewModelOutput()
+    }
+
+    private func setupView() {
+        tableView.tableFooterView = UIView(frame: .zero)
     }
 
     private func bindViewModelInput() {
@@ -41,6 +47,17 @@ final class FactListViewController: UIViewController {
             .drive(tableView.rx.items(cellIdentifier: cellType.id, cellType: cellType)) { _, itemViewModel, cell in
                 cell.viewModel = itemViewModel
             }
+            .disposed(by: bag)
+
+        input
+            .isShowingItems
+            .map(!)
+            .drive(tableView.rx.isHidden)
+            .disposed(by: bag)
+
+        input
+            .message
+            .drive(messageLabel.rx.text)
             .disposed(by: bag)
     }
 }

--- a/NorrisFacts/Modules/FactList/FactListViewModel.swift
+++ b/NorrisFacts/Modules/FactList/FactListViewModel.swift
@@ -24,7 +24,7 @@ protocol FactListViewModelProtocol {
     var output: FactListViewModelOutput { get }
 
     func bind(input: FactListViewModelInput) -> Disposable
-    func update(searchResults: [Fact])
+    func update(searchResult: SearchResult)
 }
 
 final class FactListViewModel: FactListViewModelProtocol {
@@ -34,7 +34,7 @@ final class FactListViewModel: FactListViewModelProtocol {
     private let message = PublishSubject<String>()
 
     private enum Constants {
-        static let emptySearchResults = "No results"
+        static let emptySearchResult = "No results"
     }
 
     var output: FactListViewModelOutput {
@@ -60,12 +60,16 @@ final class FactListViewModel: FactListViewModelProtocol {
             }
     }
 
-    func update(searchResults: [Fact]) {
-        if searchResults.isEmpty {
-            message.onNext(Constants.emptySearchResults)
+    func update(searchResult: SearchResult) {
+        guard case .success(let facts) = searchResult else {
+            return
         }
 
-        let itemViewModels = searchResults.map { fact in
+        if facts.isEmpty {
+            message.onNext(Constants.emptySearchResult)
+        }
+
+        let itemViewModels = facts.map { fact in
             FactListItemViewModel(value: fact.value)
         }
         itemsSubject.onNext(itemViewModels)

--- a/NorrisFacts/Modules/FactListItem/FactListItemTableViewCell.swift
+++ b/NorrisFacts/Modules/FactListItem/FactListItemTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  FactListItemTableViewCell.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/21/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import UIKit
+
+final class FactListItemTableViewCell: UITableViewCell {
+    @IBOutlet private weak var valueLabel: UILabel!
+
+    var viewModel: FactListItemViewModel? {
+        didSet {
+            updateView()
+        }
+    }
+
+    private func updateView() {
+        valueLabel.text = viewModel?.value
+    }
+}

--- a/NorrisFacts/Modules/FactListItem/FactListItemViewModel.swift
+++ b/NorrisFacts/Modules/FactListItem/FactListItemViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  FactListItemViewModel.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/21/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+
+struct FactListItemViewModel {
+    let value: String
+}

--- a/NorrisFacts/Modules/Search/FactSearchCoordinator.swift
+++ b/NorrisFacts/Modules/Search/FactSearchCoordinator.swift
@@ -10,16 +10,16 @@ import UIKit
 import RxSwift
 
 protocol FactSearchCoordinatorProtocol: Coordinator {
-    func finish(query: String?)
+    func finish(facts: [Fact]?)
 }
 
 final class FactSearchCoordinator: FactSearchCoordinatorProtocol {
     private let parent: UIViewController
     private var navigationController: UINavigationController?
     private let storyboard: StoryboardProtocol
-    private let finishHandler: (String?) -> Void
+    private let finishHandler: ([Fact]?) -> Void
 
-    init(parent: UIViewController, storyboard: StoryboardProtocol, onFinish finishHandler: @escaping (String?) -> Void) {
+    init(parent: UIViewController, storyboard: StoryboardProtocol, onFinish finishHandler: @escaping ([Fact]?) -> Void) {
         self.parent = parent
         self.storyboard = storyboard
         self.finishHandler = finishHandler
@@ -34,15 +34,16 @@ final class FactSearchCoordinator: FactSearchCoordinatorProtocol {
         navigationController.modalPresentationStyle = .fullScreen
         self.navigationController = navigationController
 
-        let viewModel = FactSearchViewModel(coordinator: self)
+        let factsProvider = FactsProvider()
+        let viewModel = FactSearchViewModel(coordinator: self, factsProvider: factsProvider)
         viewController.viewModel = viewModel
 
         parent.present(navigationController, animated: true, completion: nil)
     }
 
-    func finish(query: String?) {
+    func finish(facts: [Fact]?) {
         navigationController?.dismiss(animated: true) { [weak self] in
-            self?.finishHandler(query)
+            self?.finishHandler(facts)
         }
     }
 }

--- a/NorrisFacts/Modules/Search/FactSearchCoordinator.swift
+++ b/NorrisFacts/Modules/Search/FactSearchCoordinator.swift
@@ -10,16 +10,16 @@ import UIKit
 import RxSwift
 
 protocol FactSearchCoordinatorProtocol: Coordinator {
-    func finish(facts: [Fact]?)
+    func finish(searchResult: SearchResult)
 }
 
 final class FactSearchCoordinator: FactSearchCoordinatorProtocol {
     private let parent: UIViewController
     private var navigationController: UINavigationController?
     private let storyboard: StoryboardProtocol
-    private let finishHandler: ([Fact]?) -> Void
+    private let finishHandler: (SearchResult) -> Void
 
-    init(parent: UIViewController, storyboard: StoryboardProtocol, onFinish finishHandler: @escaping ([Fact]?) -> Void) {
+    init(parent: UIViewController, storyboard: StoryboardProtocol, onFinish finishHandler: @escaping (SearchResult) -> Void) {
         self.parent = parent
         self.storyboard = storyboard
         self.finishHandler = finishHandler
@@ -35,15 +35,17 @@ final class FactSearchCoordinator: FactSearchCoordinatorProtocol {
         self.navigationController = navigationController
 
         let factsProvider = FactsProvider()
-        let viewModel = FactSearchViewModel(coordinator: self, factsProvider: factsProvider)
+        let viewModel = FactSearchViewModel(coordinator: self,
+                                            factsProvider: factsProvider,
+                                            scheduler: MainScheduler.instance)
         viewController.viewModel = viewModel
 
         parent.present(navigationController, animated: true, completion: nil)
     }
 
-    func finish(facts: [Fact]?) {
+    func finish(searchResult: SearchResult) {
         navigationController?.dismiss(animated: true) { [weak self] in
-            self?.finishHandler(facts)
+            self?.finishHandler(searchResult)
         }
     }
 }

--- a/NorrisFacts/Modules/Search/FactSearchViewController.swift
+++ b/NorrisFacts/Modules/Search/FactSearchViewController.swift
@@ -13,6 +13,7 @@ import RxSwift
 final class FactSearchViewController: UIViewController {
     @IBOutlet private weak var searchBar: UISearchBar!
     @IBOutlet private weak var cancelBarButton: UIBarButtonItem!
+    @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
 
     private let bag = DisposeBag()
 
@@ -22,6 +23,7 @@ final class FactSearchViewController: UIViewController {
         super.viewDidLoad()
 
         bindViewModelInput()
+        bindViewModelOutput()
     }
 
     private func bindViewModelInput() {
@@ -33,6 +35,21 @@ final class FactSearchViewController: UIViewController {
 
         viewModel?
             .bind(input: input)
+            .disposed(by: bag)
+    }
+
+    private func bindViewModelOutput() {
+        guard let output = viewModel?.output else { return }
+
+        output
+            .isLoading
+            .drive(activityIndicator.rx.isAnimating)
+            .disposed(by: bag)
+
+        output
+            .isLoading
+            .map(!)
+            .drive(activityIndicator.rx.isHidden)
             .disposed(by: bag)
     }
 }

--- a/NorrisFacts/Modules/Search/FactSearchViewController.swift
+++ b/NorrisFacts/Modules/Search/FactSearchViewController.swift
@@ -51,5 +51,12 @@ final class FactSearchViewController: UIViewController {
             .map(!)
             .drive(activityIndicator.rx.isHidden)
             .disposed(by: bag)
+
+        output
+            .error
+            .drive(onNext: { [weak self] error in
+                self?.alert(error: error)
+            })
+            .disposed(by: bag)
     }
 }

--- a/NorrisFacts/Modules/Search/FactSearchViewModel.swift
+++ b/NorrisFacts/Modules/Search/FactSearchViewModel.swift
@@ -18,6 +18,7 @@ struct FactSearchViewModelInput {
 
 struct FactSearchViewModelOutput {
     let isLoading: Driver<Bool>
+    let error: Driver<ErrorDescriptor>
 }
 
 protocol FactSearchViewModelProtocol {
@@ -31,8 +32,17 @@ final class FactSearchViewModel: FactSearchViewModelProtocol {
     weak var coordinator: FactSearchCoordinatorProtocol?
 
     private let isLoadingSubject = BehaviorRelay(value: false)
+    private let errorSubject = PublishSubject<ErrorDescriptor>()
+
+    private enum Constants {
+        static let searchDebounceTime = DispatchTimeInterval.milliseconds(250)
+    }
+
     var output: FactSearchViewModelOutput {
-        .init(isLoading: isLoadingSubject.asDriver())
+        .init(
+            isLoading: isLoadingSubject.asDriver(),
+            error: errorSubject.asDriver(onErrorJustReturn: .general)
+        )
     }
 
     init(coordinator: FactSearchCoordinatorProtocol, factsProvider: FactsProviderProtocol) {
@@ -61,28 +71,55 @@ final class FactSearchViewModel: FactSearchViewModelProtocol {
             .withLatestFrom(input.searchText)
             .compactMap { $0 }
             .filter { !$0.isEmpty }
-            .distinctUntilChanged()
+            .debounce(Constants.searchDebounceTime, scheduler: MainScheduler.instance)
+
+        let searchResult = query
+            .flatMapLatest { [weak self] query -> Observable<Result<[Fact], Error>> in
+                guard let self = self else {
+                    return .empty()
+                }
+                return self.factsProvider
+                    .search(query: query)
+                    .asObservable()
+                    .mapToResult()
+            }
+            .share()
 
         return Disposables.create(
             // Loading state
-            query
-                .take(1)
-                .map { _ in true }
-                .bind(to: isLoadingSubject),
+            Observable.merge(
+                query.map { _ in true },
+                searchResult.map { _ in false }
+            )
+            .bind(to: isLoadingSubject),
 
             // Search results
-            query
-                .flatMapLatest { [weak self] query -> Observable<[Fact]> in
-                    guard let self = self else {
-                        return .empty()
-                    }
-                    return self.factsProvider
-                        .search(query: query)
-                        .asObservable()
-                }
+            searchResult
+                .compactMap { try? $0.get() }
                 .subscribe(onNext: { [weak self] facts in
                     self?.coordinator?.finish(facts: facts)
-                })
+                }),
+
+            // Search error
+            searchResult
+                .compactMap { $0.getError() }
+                .map(map(error:))
+                .bind(to: errorSubject)
         )
+    }
+
+    private func map(error: Error) -> ErrorDescriptor {
+        guard let apiError = error as? APIError else {
+            return .general
+        }
+
+        switch apiError {
+        case .serverError:
+            return .server
+        case .network:
+            return .network
+        case .underlying, .unknown, .badRequest, .redirect:
+            return .general
+        }
     }
 }

--- a/NorrisFactsTests/TestDoubles/MockFactSearchCoordinator.swift
+++ b/NorrisFactsTests/TestDoubles/MockFactSearchCoordinator.swift
@@ -10,12 +10,12 @@ import Foundation
 @testable import NorrisFacts
 
 final class MockFactSearchCoordinator: FactSearchCoordinatorProtocol {
-    var finishCalls = [String?]()
+    var finishCalls = [SearchResult]()
 
     func start() {
     }
 
-    func finish(query: String?) {
-        finishCalls.append(query)
+    func finish(searchResult: SearchResult) {
+        finishCalls.append(searchResult)
     }
 }

--- a/NorrisFactsTests/TestDoubles/MockFactsProvider.swift
+++ b/NorrisFactsTests/TestDoubles/MockFactsProvider.swift
@@ -1,0 +1,23 @@
+//
+//  MockFactsProvider.swift
+//  NorrisFactsTests
+//
+//  Created by Alan Paiva on 6/21/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+@testable import NorrisFacts
+
+final class MockFactsProvider: FactsProviderProtocol {
+    var searchResults = [Fact]()
+
+    func search(query: String) -> Single<[Fact]> {
+        .just(searchResults)
+    }
+
+    func fetchCategories() -> Single<[String]> {
+        .just([])
+    }
+}


### PR DESCRIPTION
### Trello Ticket
https://trello.com/c/HCYkVyfN

### What does this PR do?
Handles the actual search and displays, with a minimal UI, the results in the list screen. I also handled the error scenarios by showing an alert when, for whatever reason, we can't fetch facts from the API.

### Screen Recordings
| Success Search | Empty Results | Error State |
| --- | --- | --- |
| ![search-success](https://user-images.githubusercontent.com/4097324/85229029-c693fe80-b3bd-11ea-82bb-fe3577f23772.gif) | ![search-empty](https://user-images.githubusercontent.com/4097324/85229034-cbf14900-b3bd-11ea-8f56-14250d0265b4.gif) | ![search-error](https://user-images.githubusercontent.com/4097324/85229035-ce53a300-b3bd-11ea-9092-c2ca686e30fa.gif) |
 