### PR TITLE
#11/#12: [Extras]Add retry and offline-first capabilities

### DIFF
--- a/NorrisFacts.xcodeproj/project.pbxproj
+++ b/NorrisFacts.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		BDE9050D249E4FE600B2AF28 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050C249E4FE600B2AF28 /* APIError.swift */; };
 		BDE90512249E521800B2AF28 /* PrimitiveSequence+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE90511249E521800B2AF28 /* PrimitiveSequence+API.swift */; };
 		BDF8887D24A2F2340046F7AF /* PrimitiveSequence+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8887C24A2F2340046F7AF /* PrimitiveSequence+Common.swift */; };
+		BDF8888124A30A3F0046F7AF /* FactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8888024A30A3F0046F7AF /* FactStore.swift */; };
 		BDFC71B724A07A9B00D3A723 /* TitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71B624A07A9B00D3A723 /* TitleHeaderView.swift */; };
 		BDFC71B924A07F0200D3A723 /* CategoryProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71B824A07F0200D3A723 /* CategoryProviderTests.swift */; };
 		BDFC71BB24A07F8200D3A723 /* ProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71BA24A07F8200D3A723 /* ProviderTests.swift */; };
@@ -231,6 +232,7 @@
 		BDE9050C249E4FE600B2AF28 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		BDE90511249E521800B2AF28 /* PrimitiveSequence+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+API.swift"; sourceTree = "<group>"; };
 		BDF8887C24A2F2340046F7AF /* PrimitiveSequence+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+Common.swift"; sourceTree = "<group>"; };
+		BDF8888024A30A3F0046F7AF /* FactStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactStore.swift; sourceTree = "<group>"; };
 		BDFC71B624A07A9B00D3A723 /* TitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleHeaderView.swift; sourceTree = "<group>"; };
 		BDFC71B824A07F0200D3A723 /* CategoryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryProviderTests.swift; sourceTree = "<group>"; };
 		BDFC71BA24A07F8200D3A723 /* ProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderTests.swift; sourceTree = "<group>"; };
@@ -498,6 +500,7 @@
 				BD822FBC249FDC6400164C0B /* CategoryStore.swift */,
 				BD6C561824A184E30030D098 /* QueryStore.swift */,
 				BD822FC0249FDCAA00164C0B /* RealmStore.swift */,
+				BDF8888024A30A3F0046F7AF /* FactStore.swift */,
 			);
 			path = Store;
 			sourceTree = "<group>";
@@ -798,6 +801,7 @@
 				BD7BBBAB249EA19E00F1F2D8 /* String+Common.swift in Sources */,
 				BD05AC96249DB45A000F453B /* Fact.swift in Sources */,
 				BDB9BA3C249EDAFE00B0E5F2 /* FactSearchCoordinator.swift in Sources */,
+				BDF8888124A30A3F0046F7AF /* FactStore.swift in Sources */,
 				BDE90509249DBF4E00B2AF28 /* URL+Common.swift in Sources */,
 				BDE9050D249E4FE600B2AF28 /* APIError.swift in Sources */,
 				BDB9BA36249EDA0300B0E5F2 /* UIWindow.swift in Sources */,

--- a/NorrisFacts.xcodeproj/project.pbxproj
+++ b/NorrisFacts.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		BDE90512249E521800B2AF28 /* PrimitiveSequence+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE90511249E521800B2AF28 /* PrimitiveSequence+API.swift */; };
 		BDF8887D24A2F2340046F7AF /* PrimitiveSequence+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8887C24A2F2340046F7AF /* PrimitiveSequence+Common.swift */; };
 		BDF8888124A30A3F0046F7AF /* FactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8888024A30A3F0046F7AF /* FactStore.swift */; };
+		BDF8888324A39A760046F7AF /* MockFactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8888224A39A760046F7AF /* MockFactStore.swift */; };
 		BDFC71B724A07A9B00D3A723 /* TitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71B624A07A9B00D3A723 /* TitleHeaderView.swift */; };
 		BDFC71B924A07F0200D3A723 /* CategoryProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71B824A07F0200D3A723 /* CategoryProviderTests.swift */; };
 		BDFC71BB24A07F8200D3A723 /* ProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71BA24A07F8200D3A723 /* ProviderTests.swift */; };
@@ -233,6 +234,7 @@
 		BDE90511249E521800B2AF28 /* PrimitiveSequence+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+API.swift"; sourceTree = "<group>"; };
 		BDF8887C24A2F2340046F7AF /* PrimitiveSequence+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+Common.swift"; sourceTree = "<group>"; };
 		BDF8888024A30A3F0046F7AF /* FactStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactStore.swift; sourceTree = "<group>"; };
+		BDF8888224A39A760046F7AF /* MockFactStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFactStore.swift; sourceTree = "<group>"; };
 		BDFC71B624A07A9B00D3A723 /* TitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleHeaderView.swift; sourceTree = "<group>"; };
 		BDFC71B824A07F0200D3A723 /* CategoryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryProviderTests.swift; sourceTree = "<group>"; };
 		BDFC71BA24A07F8200D3A723 /* ProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderTests.swift; sourceTree = "<group>"; };
@@ -541,6 +543,7 @@
 				BDB9BA48249F067300B0E5F2 /* MockFactListCoordinator.swift */,
 				BDCEE6CA249FD1AF00CA200B /* MockFactProvider.swift */,
 				BDB9BA44249F046300B0E5F2 /* MockFactSearchCoordinator.swift */,
+				BDF8888224A39A760046F7AF /* MockFactStore.swift */,
 				BD0AFD6924A1C03300EBAE2B /* MockQueryStore.swift */,
 			);
 			path = TestDoubles;
@@ -862,6 +865,7 @@
 				BDB9BA47249F04D000B0E5F2 /* FactListViewModelTests.swift in Sources */,
 				BDDD6E2324A0876B001EAE80 /* MockCategoryStore.swift in Sources */,
 				BD0AFD6A24A1C03300EBAE2B /* MockQueryStore.swift in Sources */,
+				BDF8888324A39A760046F7AF /* MockFactStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NorrisFacts.xcodeproj/project.pbxproj
+++ b/NorrisFacts.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		BDE9050B249DCC3200B2AF28 /* Error+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050A249DCC3200B2AF28 /* Error+Common.swift */; };
 		BDE9050D249E4FE600B2AF28 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE9050C249E4FE600B2AF28 /* APIError.swift */; };
 		BDE90512249E521800B2AF28 /* PrimitiveSequence+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE90511249E521800B2AF28 /* PrimitiveSequence+API.swift */; };
+		BDF8887D24A2F2340046F7AF /* PrimitiveSequence+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8887C24A2F2340046F7AF /* PrimitiveSequence+Common.swift */; };
 		BDFC71B724A07A9B00D3A723 /* TitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71B624A07A9B00D3A723 /* TitleHeaderView.swift */; };
 		BDFC71B924A07F0200D3A723 /* CategoryProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71B824A07F0200D3A723 /* CategoryProviderTests.swift */; };
 		BDFC71BB24A07F8200D3A723 /* ProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFC71BA24A07F8200D3A723 /* ProviderTests.swift */; };
@@ -229,6 +230,7 @@
 		BDE9050A249DCC3200B2AF28 /* Error+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Common.swift"; sourceTree = "<group>"; };
 		BDE9050C249E4FE600B2AF28 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		BDE90511249E521800B2AF28 /* PrimitiveSequence+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+API.swift"; sourceTree = "<group>"; };
+		BDF8887C24A2F2340046F7AF /* PrimitiveSequence+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+Common.swift"; sourceTree = "<group>"; };
 		BDFC71B624A07A9B00D3A723 /* TitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleHeaderView.swift; sourceTree = "<group>"; };
 		BDFC71B824A07F0200D3A723 /* CategoryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryProviderTests.swift; sourceTree = "<group>"; };
 		BDFC71BA24A07F8200D3A723 /* ProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderTests.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				BDCEE6C2249F926A00CA200B /* ErrorDescriptor.swift */,
 				BDB9BA37249EDA2200B0E5F2 /* IdentifiableType.swift */,
 				BDCEE6C6249F97C300CA200B /* Observable+Common.swift */,
+				BDF8887C24A2F2340046F7AF /* PrimitiveSequence+Common.swift */,
 				BD822FBE249FDC8D00164C0B /* Realm+Rx.swift */,
 				BDCEE6C8249F97E300CA200B /* Result+Common.swift */,
 				BDB9BA39249EDA3C00B0E5F2 /* Storyboard.swift */,
@@ -835,6 +838,7 @@
 				BD7BBBA7249E98E900F1F2D8 /* HttpStatusCode.swift in Sources */,
 				BDB9BA4B249F1C2100B0E5F2 /* FactListItemTableViewCell.swift in Sources */,
 				BD735CB2249FE1A6007F6040 /* CategoryCachingWorkflow.swift in Sources */,
+				BDF8887D24A2F2340046F7AF /* PrimitiveSequence+Common.swift in Sources */,
 				BDE90512249E521800B2AF28 /* PrimitiveSequence+API.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NorrisFacts/Common/PrimitiveSequence+Common.swift
+++ b/NorrisFacts/Common/PrimitiveSequence+Common.swift
@@ -26,3 +26,12 @@ extension PrimitiveSequence where Trait == SingleTrait {
         }
     }
 }
+
+extension PrimitiveSequence where Trait == CompletableTrait {
+    func toObservable() -> Observable<Void> {
+        asObservable()
+            .materialize()
+            .take(1)
+            .map { _ in }
+    }
+}

--- a/NorrisFacts/Common/PrimitiveSequence+Common.swift
+++ b/NorrisFacts/Common/PrimitiveSequence+Common.swift
@@ -1,0 +1,28 @@
+//
+//  PrimitiveSequence+Common.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/23/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+extension PrimitiveSequence where Trait == SingleTrait {
+    func delayRetry(
+        scheduler: SchedulerType,
+        delayFunction: @escaping (Int, Error) -> Int) -> PrimitiveSequence<SingleTrait, Element> {
+        retryWhen { notifier -> Observable<Void> in
+            notifier.enumerated().flatMap { index, error -> Observable<Void> in
+                let delay = delayFunction(index, error)
+                if delay >= 0 {
+                    return Observable<Void>
+                        .just(())
+                        .delay(.seconds(delay), scheduler: scheduler)
+                }
+                return .error(error)
+            }
+        }
+    }
+}

--- a/NorrisFacts/Entity/Fact.swift
+++ b/NorrisFacts/Entity/Fact.swift
@@ -16,6 +16,10 @@ final class Fact: Object, Decodable {
     @objc dynamic var iconUrl = ""
     let categories = List<String>()
 
+    override class func primaryKey() -> String? {
+        return "id"
+    }
+
     enum CodingKeys: CodingKey {
         case id
         case url

--- a/NorrisFacts/Entity/Fact.swift
+++ b/NorrisFacts/Entity/Fact.swift
@@ -32,6 +32,14 @@ final class Fact: Object, Decodable {
         super.init()
     }
 
+    init(id: String, url: String, value: String, iconUrl: String, categories: [String]) {
+        self.id = id
+        self.url = url
+        self.value = value
+        self.iconUrl = iconUrl
+        self.categories.append(objectsIn: categories)
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)

--- a/NorrisFacts/Entity/Fact.swift
+++ b/NorrisFacts/Entity/Fact.swift
@@ -7,13 +7,34 @@
 //
 
 import Foundation
+import RealmSwift
 
-struct Fact: Decodable {
-    let id: String
-    let url: String
-    let value: String
-    let iconUrl: String
-    let categories: [String]
+final class Fact: Object, Decodable {
+    @objc dynamic var id = ""
+    @objc dynamic var url = ""
+    @objc dynamic var value = ""
+    @objc dynamic var iconUrl = ""
+    let categories = List<String>()
+
+    enum CodingKeys: CodingKey {
+        case id
+        case url
+        case value
+        case iconUrl
+        case categories
+    }
+
+    required init() {
+        super.init()
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        url = try container.decode(String.self, forKey: .url)
+        value = try container.decode(String.self, forKey: .value)
+        iconUrl = try container.decode(String.self, forKey: .iconUrl)
+        let categories = try container.decode([String].self, forKey: .categories)
+        self.categories.append(objectsIn: categories)
+    }
 }
-
-extension Fact: Equatable {}

--- a/NorrisFacts/Entity/Query.swift
+++ b/NorrisFacts/Entity/Query.swift
@@ -12,6 +12,7 @@ import RealmSwift
 final class Query: Object {
     @objc dynamic var name = ""
     @objc dynamic var updatedAt = Date()
+    let facts = List<Fact>()
 
     enum Keys {
         static let name = "name"

--- a/NorrisFacts/Modules/List/FactListCoordinator.swift
+++ b/NorrisFacts/Modules/List/FactListCoordinator.swift
@@ -33,7 +33,8 @@ final class FactListCoordinator: FactListCoordinatorProtocol {
         let navigationController = UINavigationController(rootViewController: viewController)
         self.navigationController = navigationController
 
-        let viewModel = FactListViewModel(coordinator: self)
+        let factStore = FactStore()
+        let viewModel = FactListViewModel(coordinator: self, factStore: factStore)
         viewController.viewModel = viewModel
         self.viewModel = viewModel
 

--- a/NorrisFacts/Modules/List/FactListViewModel.swift
+++ b/NorrisFacts/Modules/List/FactListViewModel.swift
@@ -64,6 +64,7 @@ final class FactListViewModel: FactListViewModelProtocol {
             // Initial random facts
             factStore
                 .sample(maxAmount: Constants.maxRandomFacts)
+                .filter { !$0.isEmpty }
                 .subscribe(onSuccess: { [weak self] facts in
                     self?.update(facts: facts)
                 }),

--- a/NorrisFacts/Modules/Search/CategoryList/CategoryListViewModel.swift
+++ b/NorrisFacts/Modules/Search/CategoryList/CategoryListViewModel.swift
@@ -66,6 +66,7 @@ final class CategoryListViewModel: CategoryListViewModelProtocol {
     private func bindCategoryTap(_ input: CategoryListViewModelInput) -> Disposable {
         input
             .categoryTap
+            .map { $0.capitalized }
             .bind(to: categoryTapSubject)
     }
 

--- a/NorrisFacts/Modules/Search/FactSearchViewModel.swift
+++ b/NorrisFacts/Modules/Search/FactSearchViewModel.swift
@@ -130,10 +130,8 @@ final class FactSearchViewModel {
             .filter { !$0.isEmpty }
             .debounce(Constants.searchDebounceTime, scheduler: scheduler)
 
-        let persistableQuery = Observable.merge(textQuery, queryTapSubject)
-
         let query = Observable
-            .merge(persistableQuery, categoryTapSubject)
+            .merge(textQuery, categoryTapSubject, queryTapSubject)
             .share()
 
         let searchResult = makeObservableSearhResult(from: query)

--- a/NorrisFacts/Modules/Search/FactSearchViewModel.swift
+++ b/NorrisFacts/Modules/Search/FactSearchViewModel.swift
@@ -167,7 +167,7 @@ final class FactSearchViewModel {
                     return .empty()
                 }
                 return self.factProvider
-                    .search(query: query, scheduler: self.scheduler)
+                    .search(query: query, scheduler: self.scheduler, retryOnError: true)
                     .asObservable()
                     .mapToResult()
             }

--- a/NorrisFacts/Modules/Search/FactSearchViewModel.swift
+++ b/NorrisFacts/Modules/Search/FactSearchViewModel.swift
@@ -141,7 +141,7 @@ final class FactSearchViewModel {
                     return .empty()
                 }
                 return self.factProvider
-                    .search(query: query)
+                    .search(query: query, scheduler: self.scheduler)
                     .asObservable()
                     .mapToResult()
             }

--- a/NorrisFacts/Modules/Search/FactSearchViewModel.swift
+++ b/NorrisFacts/Modules/Search/FactSearchViewModel.swift
@@ -53,6 +53,7 @@ final class FactSearchViewModel {
     }
 
     weak var coordinator: FactSearchCoordinatorProtocol?
+
     private let factProvider: FactProviderProtocol
     private let categoryStore: CategoryStoreProtocol
     private let queryStore: QueryStoreProtocol
@@ -135,17 +136,7 @@ final class FactSearchViewModel {
             .merge(persistableQuery, categoryTapSubject)
             .share()
 
-        let searchResult = query
-            .flatMapLatest { [weak self] query -> Observable<Result<[Fact], Error>> in
-                guard let self = self else {
-                    return .empty()
-                }
-                return self.factProvider
-                    .search(query: query, scheduler: self.scheduler)
-                    .asObservable()
-                    .mapToResult()
-            }
-            .share()
+        let searchResult = makeObservableSearhResult(from: query)
 
         return Disposables.create(
             // Loading state
@@ -166,21 +157,64 @@ final class FactSearchViewModel {
             searchResult
                 .compactMap { $0.getError() }
                 .map(map(error:))
-                .bind(to: errorSubject),
-
-            // Save query
-            searchResult
-                .withLatestFrom(persistableQuery)
-                .flatMap { [weak self] query -> Completable in
-                    guard let self = self else {
-                        return .empty()
-                    }
-
-                    let queryObject = Query(name: query)
-                    return self.queryStore.save(query: queryObject)
-                }
-                .subscribe()
+                .bind(to: errorSubject)
         )
+    }
+
+    //swiftlint:disable:next function_body_length
+    private func makeObservableSearhResult(from query: Observable<String>) -> Observable<Result<[Fact], Error>> {
+        let networkResult = query
+            .flatMapLatest { [weak self] query -> Observable<Result<[Fact], Error>> in
+                guard let self = self else {
+                    return .empty()
+                }
+                return self.factProvider
+                    .search(query: query, scheduler: self.scheduler)
+                    .asObservable()
+                    .mapToResult()
+            }
+            .share()
+
+        let networkCacheResult = networkResult
+            .withLatestFrom(query) { ($1, $0) }
+            .flatMap { [weak self] query, result -> Observable<Result<Void, Error>> in
+                guard let self = self else {
+                    return .empty()
+                }
+                switch result {
+                case .failure(let error):
+                    return .just(.failure(error))
+                case .success(let facts):
+                    let queryObject = Query(name: query)
+                    return self.queryStore
+                        .save(query: queryObject, with: facts).toObservable()
+                        .mapToResult()
+                }
+            }
+            .share()
+
+        return networkCacheResult
+            .withLatestFrom(query) { ($1, $0) }
+            .flatMap { [weak self] queryName, result -> Observable<(Query?, Error?)> in
+                guard let self = self else {
+                    return .empty()
+                }
+                return self.queryStore
+                    .getBy(name: queryName)
+                    .asObservable()
+                    .map { ($0, result.getError()) }
+            }
+            .map { query, networkError -> Result<[Fact], Error> in
+                switch (query, networkError) {
+                case let (.some(unwrappedQuery), _):
+                    return .success(Array(unwrappedQuery.facts))
+                case let (_, .some(error)):
+                    return .failure(error)
+                default:
+                    return .success([])
+                }
+            }
+            .share()
     }
 
     private func map(error: Error) -> ErrorDescriptor {

--- a/NorrisFacts/Service/Manager/CategoryManager.swift
+++ b/NorrisFacts/Service/Manager/CategoryManager.swift
@@ -34,7 +34,7 @@ final class CategoryManager: CategoryManagerProtocol {
                 }
 
                 return self.provider
-                    .fetchCategories(scheduler: self.scheduler)
+                    .fetchCategories(scheduler: self.scheduler, retryOnError: true)
                     .observeOn(ConcurrentDispatchQueueScheduler(qos: .background))
                     .flatMapCompletable { [weak self] categories -> Completable in
                         guard let self = self else {

--- a/NorrisFacts/Service/Manager/CategoryManager.swift
+++ b/NorrisFacts/Service/Manager/CategoryManager.swift
@@ -16,10 +16,12 @@ protocol CategoryManagerProtocol {
 final class CategoryManager: CategoryManagerProtocol {
     let provider: CategoryProviderProtocol
     let store: CategoryStoreProtocol
+    let scheduler: SchedulerType
 
-    init(provider: CategoryProviderProtocol, store: CategoryStoreProtocol) {
+    init(provider: CategoryProviderProtocol, store: CategoryStoreProtocol, scheduler: ConcurrentDispatchQueueScheduler) {
         self.provider = provider
         self.store = store
+        self.scheduler = scheduler
     }
 
     func cacheCategoriesIfNeeded() -> Completable {
@@ -32,7 +34,7 @@ final class CategoryManager: CategoryManagerProtocol {
                 }
 
                 return self.provider
-                    .fetchCategories()
+                    .fetchCategories(scheduler: self.scheduler)
                     .observeOn(ConcurrentDispatchQueueScheduler(qos: .background))
                     .flatMapCompletable { [weak self] categories -> Completable in
                         guard let self = self else {

--- a/NorrisFacts/Service/Provider/ChuckNorrisAPI/CategoryProvider.swift
+++ b/NorrisFacts/Service/Provider/ChuckNorrisAPI/CategoryProvider.swift
@@ -12,13 +12,13 @@ import RxMoya
 import RxSwift
 
 protocol CategoryProviderProtocol {
-    func fetchCategories() -> Single<[Category]>
+    func fetchCategories(scheduler: SchedulerType) -> Single<[Category]>
 }
 
 struct CategoryProvider: CategoryProviderProtocol {
     private let provider = MoyaProvider<ChuckNorrisAPI>()
 
-    func fetchCategories() -> Single<[Category]> {
+    func fetchCategories(scheduler: SchedulerType) -> Single<[Category]> {
         provider
             .rx
             .request(.categories)
@@ -26,5 +26,6 @@ struct CategoryProvider: CategoryProviderProtocol {
             .map([String].self)
             .map { $0.map { Category(name: $0) } }
             .catchErrorReturnAPIError()
+            .retryWhenNetworkOrServerError(scheduler: scheduler)
     }
 }

--- a/NorrisFacts/Service/Provider/ChuckNorrisAPI/FactProvider.swift
+++ b/NorrisFacts/Service/Provider/ChuckNorrisAPI/FactProvider.swift
@@ -12,21 +12,25 @@ import RxMoya
 import RxSwift
 
 protocol FactProviderProtocol {
-    func search(query: String, scheduler: SchedulerType) -> Single<[Fact]>
+    func search(query: String, scheduler: SchedulerType, retryOnError: Bool) -> Single<[Fact]>
 }
 
 struct FactProvider: FactProviderProtocol {
     private let provider = MoyaProvider<ChuckNorrisAPI>()
 
-    func search(query: String, scheduler: SchedulerType) -> Single<[Fact]> {
-        provider
+    func search(query: String, scheduler: SchedulerType, retryOnError: Bool) -> Single<[Fact]> {
+        let result = provider
             .rx
             .request(.search(query: query))
             .filterSuccessfulStatusCodes()
             .map(FactListResult.self, using: .default, failsOnEmptyData: true)
             .map { $0.result }
             .catchErrorReturnAPIError()
-            .retryWhenNetworkOrServerError(scheduler: ConcurrentDispatchQueueScheduler(qos: .background))
+
+        if retryOnError {
+            return result.retryWhenNetworkOrServerError(scheduler: ConcurrentDispatchQueueScheduler(qos: .background))
+        }
+        return result
     }
 }
 

--- a/NorrisFacts/Service/Provider/ChuckNorrisAPI/FactProvider.swift
+++ b/NorrisFacts/Service/Provider/ChuckNorrisAPI/FactProvider.swift
@@ -12,13 +12,13 @@ import RxMoya
 import RxSwift
 
 protocol FactProviderProtocol {
-    func search(query: String) -> Single<[Fact]>
+    func search(query: String, scheduler: SchedulerType) -> Single<[Fact]>
 }
 
 struct FactProvider: FactProviderProtocol {
     private let provider = MoyaProvider<ChuckNorrisAPI>()
 
-    func search(query: String) -> Single<[Fact]> {
+    func search(query: String, scheduler: SchedulerType) -> Single<[Fact]> {
         provider
             .rx
             .request(.search(query: query))
@@ -26,6 +26,7 @@ struct FactProvider: FactProviderProtocol {
             .map(FactListResult.self, using: .default, failsOnEmptyData: true)
             .map { $0.result }
             .catchErrorReturnAPIError()
+            .retryWhenNetworkOrServerError(scheduler: ConcurrentDispatchQueueScheduler(qos: .background))
     }
 }
 

--- a/NorrisFacts/Service/Provider/Common/PrimitiveSequence+API.swift
+++ b/NorrisFacts/Service/Provider/Common/PrimitiveSequence+API.swift
@@ -41,4 +41,16 @@ extension PrimitiveSequence where Trait == SingleTrait {
             return .error(APIError.underlying(afError))
         }
     }
+
+    func retryWhenNetworkOrServerError(scheduler: SchedulerType) -> PrimitiveSequence<Trait, Element> {
+        delayRetry(scheduler: scheduler) { index, error -> Int in
+            guard index < 2, let apiError = error as? APIError else { return -1 }
+            switch apiError {
+            case .network, .serverError:
+                return (index + 1) * 4
+            default:
+                return -1
+            }
+        }
+    }
 }

--- a/NorrisFacts/Service/Store/FactStore.swift
+++ b/NorrisFacts/Service/Store/FactStore.swift
@@ -1,0 +1,27 @@
+//
+//  FactStore.swift
+//  NorrisFacts
+//
+//  Created by Alan Paiva on 6/24/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+protocol FactStoreProtocol: RealmStore {
+    func sample(maxAmount: Int) -> Single<[Fact]>
+}
+
+final class FactStore: FactStoreProtocol {
+    func sample(maxAmount: Int) -> Single<[Fact]> {
+        realm()
+            .map { realm -> [Fact] in
+                let results = realm.objects(Fact.self)
+                let indexes = (0..<results.count)
+                    .shuffled()
+                    .prefix(maxAmount)
+                return indexes.map { results[$0] }
+            }
+    }
+}

--- a/NorrisFacts/Service/Store/QueryStore.swift
+++ b/NorrisFacts/Service/Store/QueryStore.swift
@@ -12,7 +12,8 @@ import RxSwift
 
 protocol QueryStoreProtocol: RealmStore {
     func all(limit: Int) -> Single<[Query]>
-    func save(query: Query) -> Completable
+    func getBy(name: String) -> Single<Query?>
+    func save(query: Query, with fact: [Fact]) -> Completable
 }
 
 final class QueryStore: QueryStoreProtocol {
@@ -26,10 +27,19 @@ final class QueryStore: QueryStoreProtocol {
             .map { Array($0.prefix(limit)) }
     }
 
-    func save(query: Query) -> Completable {
+    func getBy(name: String) -> Single<Query?> {
+        realm()
+            .map { realm in
+                realm.object(ofType: Query.self, forPrimaryKey: name)
+            }
+    }
+
+    func save(query: Query, with fact: [Fact]) -> Completable {
         realm()
             .flatMapCompletable { realm -> Completable in
                 realm.writeCompletable {
+                    realm.add(fact, update: .modified)
+                    query.facts.append(objectsIn: fact)
                     realm.add(query, update: .modified)
                 }
             }

--- a/NorrisFacts/Service/Store/QueryStore.swift
+++ b/NorrisFacts/Service/Store/QueryStore.swift
@@ -13,7 +13,7 @@ import RxSwift
 protocol QueryStoreProtocol: RealmStore {
     func all(limit: Int) -> Single<[Query]>
     func getBy(name: String) -> Single<Query?>
-    func save(query: Query, with fact: [Fact]) -> Completable
+    func save(query: Query, with facts: [Fact]) -> Completable
 }
 
 final class QueryStore: QueryStoreProtocol {
@@ -34,12 +34,12 @@ final class QueryStore: QueryStoreProtocol {
             }
     }
 
-    func save(query: Query, with fact: [Fact]) -> Completable {
+    func save(query: Query, with facts: [Fact]) -> Completable {
         realm()
             .flatMapCompletable { realm -> Completable in
                 realm.writeCompletable {
-                    realm.add(fact, update: .modified)
-                    query.facts.append(objectsIn: fact)
+                    realm.add(facts, update: .modified)
+                    query.facts.append(objectsIn: facts)
                     realm.add(query, update: .modified)
                 }
             }

--- a/NorrisFacts/Service/Workflow/CategoryCachingWorkflow.swift
+++ b/NorrisFacts/Service/Workflow/CategoryCachingWorkflow.swift
@@ -19,7 +19,8 @@ final class CategoryCachingWorkflow: Workflow {
 
     init() {
         manager = CategoryManager(provider: CategoryProvider(),
-                                  store: CategoryStore())
+                                  store: CategoryStore(),
+                                  scheduler: ConcurrentDispatchQueueScheduler(qos: .background))
     }
     func start() {
         manager

--- a/NorrisFactsTests/IntegrationTests/CategoryProviderTests.swift
+++ b/NorrisFactsTests/IntegrationTests/CategoryProviderTests.swift
@@ -9,6 +9,7 @@
 import Quick
 import Nimble
 import OHHTTPStubs
+import RxSwift
 @testable import NorrisFacts
 
 final class CategoryProviderTests: QuickSpec {
@@ -25,7 +26,7 @@ final class CategoryProviderTests: QuickSpec {
 
                         let provider = CategoryProvider()
                         let result = provider
-                            .fetchCategories()
+                            .fetchCategories(scheduler: MainScheduler.instance, retryOnError: false)
                             .toBlocking()
                             .materialize()
 
@@ -66,7 +67,7 @@ final class CategoryProviderTests: QuickSpec {
 
                             let provider = CategoryProvider()
                             let result = provider
-                                .fetchCategories()
+                                .fetchCategories(scheduler: MainScheduler.instance, retryOnError: false)
                                 .toBlocking()
                                 .materialize()
 

--- a/NorrisFactsTests/IntegrationTests/FactProviderTests.swift
+++ b/NorrisFactsTests/IntegrationTests/FactProviderTests.swift
@@ -28,7 +28,7 @@ final class FactProviderTests: QuickSpec {
 
                         let provider = FactProvider()
                         let result = provider
-                            .search(query: query)
+                            .search(query: query, scheduler: MainScheduler.instance, retryOnError: false)
                             .toBlocking()
                             .materialize()
 
@@ -46,7 +46,8 @@ final class FactProviderTests: QuickSpec {
                         expect(facts[0].id).to(equal("dwxnerd8qamdgrzsl9aakq"))
                         expect(facts[0].iconUrl).to(equal("https://assets.chucknorris.host/img/avatar/chuck-norris.png"))
                         expect(facts[0].url).to(equal("https://api.chucknorris.io/jokes/dwxnerd8qamdgrzsl9aakq"))
-                        expect(facts[0].categories).to(equal(["history", "career"]))
+                        expect(facts[0].categories[0]).to(equal("history"))
+                        expect(facts[0].categories[1]).to(equal("career"))
                         expect(facts[0].value).to(equal(
                             #"The term "Cleveland Steamer" got its name from Chuck Norris, "# +
                             "when he took a dump while visiting the Rock and Roll Hall of " +
@@ -57,7 +58,7 @@ final class FactProviderTests: QuickSpec {
                         expect(facts[1].id).to(equal("lr9litcitfmul3qjx_3mmw"))
                         expect(facts[1].iconUrl).to(equal("https://assets.chucknorris.host/img/avatar/chuck-norris.png"))
                         expect(facts[1].url).to(equal("https://api.chucknorris.io/jokes/lr9litcitfmul3qjx_3mmw"))
-                        expect(facts[1].categories).to(equal(["political"]))
+                        expect(facts[1].categories[0]).to(equal("political"))
                         expect(facts[1].value).to(equal(
                             "Thousands of years ago Chuck Norris came across a bear. " +
                             "It was so terrified that it fled north into the arctic. " +

--- a/NorrisFactsTests/TestDoubles/MockFactProvider.swift
+++ b/NorrisFactsTests/TestDoubles/MockFactProvider.swift
@@ -13,11 +13,7 @@ import RxSwift
 final class MockFactProvider: FactProviderProtocol {
     var searchResults = [Fact]()
 
-    func search(query: String) -> Single<[Fact]> {
+    func search(query: String, scheduler: SchedulerType, retryOnError: Bool) -> Single<[Fact]> {
         .just(searchResults)
-    }
-
-    func fetchCategories() -> Single<[String]> {
-        .just([])
     }
 }

--- a/NorrisFactsTests/TestDoubles/MockFactStore.swift
+++ b/NorrisFactsTests/TestDoubles/MockFactStore.swift
@@ -1,0 +1,17 @@
+//
+//  MockFactStore.swift
+//  NorrisFactsTests
+//
+//  Created by Alan Paiva on 6/24/20.
+//  Copyright © 2020 Alan Paiva. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+@testable import NorrisFacts
+
+final class MockFactStore: FactStoreProtocol {
+    func sample(maxAmount: Int) -> Single<[Fact]> {
+        .just([])
+    }
+}

--- a/NorrisFactsTests/TestDoubles/MockQueryStore.swift
+++ b/NorrisFactsTests/TestDoubles/MockQueryStore.swift
@@ -11,11 +11,26 @@ import RxSwift
 @testable import NorrisFacts
 
 final class MockQueryStore: QueryStoreProtocol {
+    var savedQueries = [Query]()
+
     func all(limit: Int) -> Single<[Query]> {
-        return .just([])
+        .just([])
     }
 
-    func save(query: Query) -> Completable {
-        return .empty()
+    func getBy(name: String) -> Single<Query?> {
+        Single.create { [unowned self] single -> Disposable in
+            let query = self.savedQueries.first { $0.name == name }
+            single(.success(query))
+            return Disposables.create()
+        }
+    }
+
+    func save(query: Query, with facts: [Fact]) -> Completable {
+        Completable.create { [unowned self] completable -> Disposable in
+            query.facts.append(objectsIn: facts)
+            self.savedQueries.append(query)
+            completable(.completed)
+            return Disposables.create()
+        }
     }
 }

--- a/NorrisFactsTests/UnitTests/FactListViewModelTests.swift
+++ b/NorrisFactsTests/UnitTests/FactListViewModelTests.swift
@@ -16,15 +16,18 @@ final class FactListViewModelTests: QuickSpec {
     override func spec() {
         describe("FactListViewModel") {
             var coordinator: MockFactListCoordinator!
+            var factStore: MockFactStore!
             var viewModel: FactListViewModel!
 
             beforeEach {
                 coordinator = MockFactListCoordinator()
-                viewModel = FactListViewModel(coordinator: coordinator)
+                factStore = MockFactStore()
+                viewModel = FactListViewModel(coordinator: coordinator, factStore: factStore)
             }
 
             afterEach {
                 coordinator = nil
+                factStore = nil
                 viewModel = nil
             }
 


### PR DESCRIPTION
### Trello Tickets
https://trello.com/c/mjd8M8oX
https://trello.com/c/CyewwOg3

### What does this PR do?

* **Adds retry capability to providers**. If a network request failures, providers will retry at maximum twice. The first try is delayed 4s and the second try 8s.

* **Caches search results**. `Fact` entity is now a Realm object and it has a many-to-many relationship with `Query`. So now we persist search results after each successful search.

* **Persistent store is the one source of truth**. All facts we display on-screen are now retrieved from a Realm.

* Displays random facts (if any) on List screen in the first time it is viewed.